### PR TITLE
updated var type in LogicalInterface struct from int to uint64 for si…

### DIFF
--- a/views.go
+++ b/views.go
@@ -84,17 +84,17 @@ type LogicalInterface struct {
 	LocalIndex         int    `xml:"local-index"`
 	SNMPIndex          int    `xml:"snmp-index"`
 	Encapsulation      string `xml:"encapsulation"`
-	LAGInputPackets    int    `xml:"lag-traffic-statistics>lag-bundle>input-packets"`
+	LAGInputPackets    uint64    `xml:"lag-traffic-statistics>lag-bundle>input-packets"`
 	LAGInputPps        int    `xml:"lag-traffic-statistics>lag-bundle>input-pps"`
 	LAGInputBytes      int    `xml:"lag-traffic-statistics>lag-bundle>input-bytes"`
 	LAGInputBps        int    `xml:"lag-traffic-statistics>lag-bundle>input-bps"`
-	LAGOutputPackets   int    `xml:"lag-traffic-statistics>lag-bundle>output-packets"`
+	LAGOutputPackets   uint64    `xml:"lag-traffic-statistics>lag-bundle>output-packets"`
 	LAGOutputPps       int    `xml:"lag-traffic-statistics>lag-bundle>output-pps"`
 	LAGOutputBytes     int    `xml:"lag-traffic-statistics>lag-bundle>output-bytes"`
 	LAGOutputBps       int    `xml:"lag-traffic-statistics>lag-bundle>output-bps"`
 	ZoneName           string `xml:"logical-interface-zone-name"`
-	InputPackets       int    `xml:"traffic-statistics>input-packets"`
-	OutputPackets      int    `xml:"traffic-statistics>output-packets"`
+	InputPackets       uint64    `xml:"traffic-statistics>input-packets"`
+	OutputPackets      uint64    `xml:"traffic-statistics>output-packets"`
 	AddressFamily      string `xml:"address-family>address-family-name"`
 	AggregatedEthernet string `xml:"address-family>ae-bundle-name,omitempty"`
 	LinkAddress        string `xml:"link-address,omitempty"`


### PR DESCRIPTION
…me fields.

This fixes the problem when interface stats values at some point can't fit into int type.

The error looked like this:
strconv.ParseInt: parsing "12480462034870436376": value out of range
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x12716d5]